### PR TITLE
Fix no fraud_status attribute in cimb_click cancel response

### DIFF
--- a/app/code/community/Veritrans/Vtweb/controllers/PaymentController.php
+++ b/app/code/community/Veritrans/Vtweb/controllers/PaymentController.php
@@ -401,6 +401,9 @@ class Veritrans_Vtweb_PaymentController
         $logs .= 'accept ';
         $order->setStatus('canceled');
       }
+      else {
+        $order->setStatus('canceled');
+      }
     }
     else if ($transaction == 'deny') {
       $logs .= 'deny ';


### PR DESCRIPTION
Currently veritrans doesn't have fraud_status in payment cancel response, so magento sales order can't be updated in current flow.